### PR TITLE
GitHub Actions build-and-push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: build-and-push
 on:
   push:
     branches:
-      - github-build
+      - master
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/notalone:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mhproject:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: build-and-push
+
+on:
+  push:
+    branches:
+      - github-build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/notalone:latest

--- a/README.md
+++ b/README.md
@@ -180,3 +180,15 @@ The main idea is to have two containers running, one for the database (PostgreSQ
 - `./docker-compose.yml` # It contains the Docker definitions, environment variables, volumes and ports usage
 
 On the last file you can modify the main environment variable for Rails `RAILS_ENV`, by default the value is "development" but you cand change it for test or production based on your requirements.
+
+### Automatic Build&Push the Docker image
+
+We can use the Dockerhub or any other container registry to publish this Docker image and anyone can deploy it on their own local computer, VPS (virtual private
+server) or any other cloud resource which can execute containers (GKE, ECS, AKS or something similar).
+
+The firts step of GitHub Actions use the Docker official images to login, to build and push the image into the Dockerhub (container registry); so we need
+to setup two initial secrets values into the [Github repository configuration](https://github.com/adrianagithub/mhproject/settings/secrets/actions) add
+these variables:
+
+- **DOCKERHUB_USERNAME** the value required here is the username of the Dockerhub account (for example `adrianaprojects`)
+- **DOCKERHUB_TOKEN** the value required here is the [Access token from your account](https://hub.docker.com/settings/security)


### PR DESCRIPTION
This is the next step after the previous effort, now we can use the Dockerized project to follow the CI/CD workflow:

1. Build the Docker image with the project code, after a new merge to the "main" branch.
2. Push the Docker image to a container registry where anyone can use it.
3. Deploy that Docker image into a Cloud resource and publish the result through a domain name on the Internet.

The last step is incoming work ... the scope of this pull request is to build and push the Docker image, using a popular (and free for open-source projects) container registry like Dockerhub. The evidence is here:
- https://hub.docker.com/r/adrianaprojects/mhproject/tags

References:
- https://docs.docker.com/build/ci/github-actions/
